### PR TITLE
Urls for django 1.10

### DIFF
--- a/django_pydenticon/urls.py
+++ b/django_pydenticon/urls.py
@@ -3,14 +3,9 @@ from django.conf.urls import patterns, url
 
 # Application imports.
 from .views import image
-
-urlpatterns = patterns(
-    'django_pydenticon.views',
-
-    # View for rendering an identicon image.
-    url(r'^image/(?P<data>.+)$', image, name="image")
-    )
-
+urlpatterns = [
+    url(r'^image/(?P<data>.+)$', image, name="image"),
+]
 def get_patterns(instance="django_pydenticon"):
     """
     Generates URL patterns for Django Pydenticon application. The return value


### PR DESCRIPTION
Remove django.conf.urls.patterns(), is deprecated in Django in 1.10
